### PR TITLE
Fix pylint violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ The motive is to allow access to users unable to play mp4 video; more
 specifically, to allow content to be accessible to the OLPC XO laptops.
 
 As of now, `mp42ogv.py` does not exist.
-Instead there is `convert2ogv.py3` which converts the ogv files to mp4
-and `scan4html.py3` which changes the link references.
+Instead there is `convert2ogv.py` which converts the ogv files to mp4
+and `scan4html.py` which changes the link references.
 

--- a/convert2ogv.py
+++ b/convert2ogv.py
@@ -3,24 +3,25 @@
 # vim: set fileencoding=utf-8 :
 # Copyright 2014 Alex Kleider; All Rights Reserved.
 
-# file: 'convert2ogv.py3'
+# file: 'convert2ogv.py'
 """
-convert2ogv.py3 
+convert2ogv.py
 to scan for all '.mp4' files and convert them to '.ogv'.
 
 !!!!!!!!!!!!        BE SURE TO SET ROOT_DIR        !!!!!!!!!!!
 !!!  And decide if you want DELETE_ORIGINALS to be True or False. !!!
 
-Sister procedure is 'scan4html.py3'
-to traverse a directory tree and within any html file 
+Sister procedure is 'scan4html.py'
+to traverse a directory tree and within any html file
 preform a substitution of ".ogv" for any instance of ".mp4".
 """
 
-print("Running Python3 script: 'convert2ogv.py3'.......")
+print("Running Python3 script: 'convert2ogv.py'.......")
 
 import os
 import subprocess
 import shlex
+import sys
 
 ROOT_DIR = "/home/alex/Python/Conversion/Test"
 #DELETE_ORIGINALS = False
@@ -29,9 +30,12 @@ DELETE_ORIGINALS = True
 OLD_SUFFIX = '.mp4'
 NEW_SUFFIX = '.ogv'
 
+
+"""Main loop for command processing"""
+
 command_line = "avconv -i {0}{1} -acodec libvorbis -q 0 {0}{2}"
 
-x = subprocess.call("date")
+subprocess.call("date")
 
 response = input("""Root directory of files to be converted is set to..
 {0}
@@ -46,6 +50,7 @@ else:
 n_files = 0
 n_conversions = 0
 
+# pylint: disable=W0612
 for root, dirs, files in os.walk(ROOT_DIR):
     #print("Traversing...")
     for f_name in files:
@@ -53,15 +58,15 @@ for root, dirs, files in os.walk(ROOT_DIR):
         if f_name.endswith(OLD_SUFFIX):
             n_conversions += 1
             f_name_without_suffix = f_name[:-len(OLD_SUFFIX)]
-            full_path = os.path.join(root, f_name)
             full_path_without_suffix = \
                             os.path.join(root, f_name_without_suffix)
-            print("  {0:>4}. {1}".format(n_conversions, full_path_without_suffix))
+            print("  {0:>4}. {1}".format(n_conversions,
+                                         full_path_without_suffix))
 
             args = shlex.split(command_line.\
                 format(full_path_without_suffix, OLD_SUFFIX, NEW_SUFFIX))
-            y = subprocess.call(args)
-            z = subprocess.call("date")
+            subprocess.call(args)
+            subprocess.call("date")
             if DELETE_ORIGINALS:
                 os.remove('{0}{1}'\
                         .format(full_path_without_suffix, OLD_SUFFIX))
@@ -70,5 +75,4 @@ for root, dirs, files in os.walk(ROOT_DIR):
 
 print("Files checked: {};  Files converted: {}.".\
                                     format(n_files, n_conversions))
-
 

--- a/rmogv.py
+++ b/rmogv.py
@@ -8,7 +8,7 @@
 Removes files with names ending in FILE_NAME_SUFFIX, 
 currently set to '.ogv'
 This is a utility which removes the ogv files created by 
-convert2ogv.py3, useful when testing so you can delete the files 
+convert2ogv.py, useful when testing so you can delete the files 
 created when testing (as long as you've done it 
 DELETE_ORIGINALS set to False.)
 """

--- a/scan4html.py
+++ b/scan4html.py
@@ -3,15 +3,15 @@
 # vim: set fileencoding=utf-8 :
 # Copyright 2014 Alex Kleider; All Rights Reserved.
 
-# file: 'scan4html.py3'
+# file: 'scan4html.py'
 """
-Want to be able to traverse a directory tree and preform a substitution 
+Want to be able to traverse a directory tree and preform a substitution
 of ".ogv" for any instance of ".mp4".
 
-Sister procedure is convert2ogv.py3 
+Sister procedure is convert2ogv.py
 to scan for all '.mp4' files and convert them to '.ogv'.
 """
-print("Running Python3 script: 'scan4html.py3'.......")
+print("Running Python3 script: 'scan4html.py'.......")
 
 import os
 import sys
@@ -25,7 +25,7 @@ MODE = "debug"
 #MODE = "production"
 
 if MODE == "production":
-    NEW_FILE_PREFIX = ''  #  IN PRODUCTION MODE 
+    NEW_FILE_PREFIX = ''  #  IN PRODUCTION MODE
         # in production mode we don't rename, we replace.
     ROOT_DIR = "/home/alex/Python/Conversion/WWW"
     OLD = '.mp4'
@@ -38,7 +38,7 @@ else:  # MODE == "debug"
 
 FILE_NAME_SUFFIX = ".html"
 
-print(""" 
+print("""
 #####################################
    #   Running in {0} mode.    #
    #   TEST is set to {1}.     #
@@ -66,7 +66,8 @@ else:
 
 
 def convert_text(text, old, new):
-    if text.find(old) >=0:
+    """Replace 'old' text with 'new' text inside variable text"""
+    if text.find(old) >= 0:
         return text.replace(old, new)
 
 for root, dirs, files in os.walk(ROOT_DIR):


### PR DESCRIPTION
To get a 10/10 pylint score, one would need to structurally change the program in a more modular way. However, a reasonable score can be obtained without doing so. For example, convert2ogv.py can have a 8.82/10 score and scan4html.py can have a 9.78/10 score.

This is sufficient as a natural restructuring will over time make these scores rise to 10/10.

There is a line that has no function (a variable is defined but is not used). Commit b967516 makes this code dead and comments this line with phrase FIX. This line is not being used in the rest of the program and will be removed.
